### PR TITLE
Use official memcache store adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Alternatively, you can pass these options to config.cache_store (also
 in production.rb):
 
 ```ruby
-config.cache_store = :dalli_store, ENV["MEMCACHIER_SERVERS"].split(','),
+config.cache_store = :mem_cache_store, ENV["MEMCACHIER_SERVERS"].split(','),
                     {:username => ENV["MEMCACHIER_USERNAME"],
                      :password => ENV["MEMCACHIER_PASSWORD"]}
 ```
@@ -124,7 +124,7 @@ Ensure that the following configuration option is set in production.rb:
 
 ```ruby
 # Configure rails caching (action, fragment)
-config.cache_store = :dalli_store
+config.cache_store = :mem_cache_store
 
 # Configure Rack::Cache (rack middleware, whole page / static assets)
 client = Dalli::Client.new(ENV["MEMCACHIER_SERVERS"],

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module Example
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    config.cache_store = :dalli_store
+    config.cache_store = :mem_cache_store
 
 
     # Custom directories with classes and modules you want to be autoloadable.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,9 +23,9 @@ Example::Application.configure do
   # --------------------------------------------------------------------------
   # MEMCACHIER
   # ----------
- 
+
   # Configure rails caching (action, fragment)
-  config.cache_store = :dalli_store
+  config.cache_store = :mem_cache_store
 
   # Configure Rack::Cache (rack middleware, whole page / static assets) (we set
   # value_max_bytes to 10MB, most memcache servers won't allow values larger


### PR DESCRIPTION
Rails ships with it's own cache adapter on top of dalli. This isn't a big deal in Rails 4.2 but in Rails 5.2 the :dalli_store is not compatible with all caching options and can fail to invalidate silently.